### PR TITLE
Bug no. 39 - Readonly pole se ukládá, lze změnit termín přidáním term_id

### DIFF
--- a/app/Http/Requests/Student/UpdateStudentRequest.php
+++ b/app/Http/Requests/Student/UpdateStudentRequest.php
@@ -17,8 +17,8 @@ class UpdateStudentRequest extends CreateStudentRequest
         $term = $this->route()->student->term;
         $rules = parent::rules($term);
 
-        unset($rules['forename']);
-        unset($rules['surname']);
+        // unset($rules['forename']);
+        // unset($rules['surname']);
         unset($rules['terms_conditions']);
 
         return $rules;
@@ -31,9 +31,12 @@ class UpdateStudentRequest extends CreateStudentRequest
     {
         $data = parent::getData($addTerm);
 
-        unset($data['term_id']);
-        unset($data['forename']);
-        unset($data['surname']);
+        if ($data['term_id'] === null) {
+            unset($data['term_id']);
+        }
+
+        // unset($data['forename']);
+        // unset($data['surname']);
 
         return $data;
     }


### PR DESCRIPTION
Při úpravě přihlášky rodičem lze v HTML odebrat readonly atribut a ukládat tak hodnotu.
Navíc přidáním pole term_id lze změnit i termín přihlášky. Příklad ve Wiki